### PR TITLE
PR #3 - Gestionnaire de Chapitres

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,8 +183,15 @@ Chaque PR doit passer les 6 tests critiques :
 - 13 tests unitaires avec approche TDD
 - Code formaté et validé avec flake8
 
+### ✅ PR #3 - Gestionnaire de Chapitres (Complété)
+- ✅ Endpoints CRUD pour les chapitres (/api/projects/{id}/chapters)
+- ✅ Gestion automatique de l'ordre des chapitres (position)
+- ✅ Import/Export Markdown avec extraction de titre H1
+- ✅ Réorganisation des chapitres (bulk reorder)
+- ✅ 18 tests unitaires complets
+- ✅ Code formaté (black) et validé (flake8)
+
 ### 🔄 Prochaines Étapes
-- PR #3: Gestionnaire de Chapitres
 - PR #4: Éditeur Monaco Intégré
 - PR #5: Processeur Markdown
 - PR #6: Templates et Styles CSS
@@ -195,9 +202,17 @@ Chaque PR doit passer les 6 tests critiques :
 - PR #11: Système de Versions
 - PR #12: Interface Utilisateur Complète
 
+## 🔗 Repository GitHub
+- **URL**: https://github.com/julienhypeer/book-generator (privé)
+- **Issues ouvertes**:
+  - #2: Migrer vers PostgreSQL pour production
+  - #3: Embarquer fonts localement
+  - #4: Ajouter limites mémoire pour WeasyPrint
+  - #5: Versionner les templates CSS
+
 ## 📚 Documentation Détaillée
 
 - Architecture Frontend → `/frontend/CLAUDE.md`
-- Architecture Backend → `/backend/CLAUDE.md` ✅ (Mis à jour avec PR #1)
+- Architecture Backend → `/backend/CLAUDE.md` ✅ (Mis à jour avec PR #1 et #2)
 - Docker Setup → `/docker/CLAUDE.md`
 - Tests Strategy → `/tests/CLAUDE.md`

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -214,15 +214,24 @@ async def health_check():
 - ✅ 13 tests unitaires pour les endpoints
 - ✅ Code formaté et linté
 
+### PR #3 - Gestionnaire de Chapitres (Complété)
+- ✅ Schémas Pydantic pour chapters (ChapterCreate, ChapterUpdate, ChapterResponse)
+- ✅ Service ChapterService avec gestion automatique des positions
+- ✅ Endpoints CRUD complets (/api/projects/{id}/chapters)
+- ✅ Import/Export Markdown avec extraction H1
+- ✅ Réorganisation bulk des chapitres
+- ✅ 18 tests unitaires complets
+- ✅ Code formaté et linté
+
 ### Structure Actuelle
 ```
 /app
   /core         → Configuration (database, pdf, storage) ✅
   /models       → Modèles SQLAlchemy (Project, Chapter) ✅
-  /api          → Endpoints REST (projects) ✅
-  /services     → Services (ProjectService) ✅
+  /api          → Endpoints REST (projects, chapters) ✅
+  /services     → Services (ProjectService, ChapterService) ✅
   /tasks        → Tâches Celery (à venir - PR #8)
-  /validators   → Schémas Pydantic (project) ✅
+  /validators   → Schémas Pydantic (project, chapter) ✅
 ```
 
 ## 🔧 Commandes

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,5 +1,6 @@
 """API endpoints."""
 
 from .projects import router as projects_router
+from .chapters import router as chapters_router
 
-__all__ = ["projects_router"]
+__all__ = ["projects_router", "chapters_router"]

--- a/backend/app/api/chapters.py
+++ b/backend/app/api/chapters.py
@@ -1,0 +1,192 @@
+"""API endpoints for Chapter management."""
+
+from typing import List
+from fastapi import APIRouter, Depends, HTTPException, status, Response, Request
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db_session
+from app.services.chapter import ChapterService
+from app.validators.chapter import (
+    ChapterCreate,
+    ChapterUpdate,
+    ChapterResponse,
+    BulkChapterReorder,
+)
+
+router = APIRouter(prefix="/api/projects/{project_id}/chapters", tags=["chapters"])
+
+
+def get_chapter_service(db: Session = Depends(get_db_session)) -> ChapterService:
+    """Dependency to get ChapterService instance."""
+    return ChapterService(db)
+
+
+# Create chapter endpoint
+@router.post("", response_model=ChapterResponse, status_code=status.HTTP_201_CREATED)
+def create_chapter(
+    project_id: int,
+    chapter_data: ChapterCreate,
+    service: ChapterService = Depends(get_chapter_service),
+) -> ChapterResponse:
+    """Create a new chapter for a project."""
+    try:
+        chapter = service.create_chapter(project_id, chapter_data)
+        return ChapterResponse.model_validate(chapter)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+
+# List chapters endpoint
+@router.get("", response_model=List[ChapterResponse])
+def list_chapters(
+    project_id: int,
+    service: ChapterService = Depends(get_chapter_service),
+) -> List[ChapterResponse]:
+    """List all chapters for a project."""
+    chapters = service.list_chapters(project_id)
+    return [ChapterResponse.model_validate(ch) for ch in chapters]
+
+
+# Export all chapters endpoint (must be before /{chapter_id} routes)
+@router.get("/export")
+def export_all_chapters(
+    project_id: int,
+    include_metadata: bool = False,
+    service: ChapterService = Depends(get_chapter_service),
+) -> Response:
+    """Export all chapters as a single Markdown file."""
+    markdown = service.export_all_chapters_markdown(project_id, include_metadata)
+    return Response(
+        content=markdown,
+        media_type="text/markdown; charset=utf-8",
+        headers={
+            "Content-Disposition": f"attachment; filename=project_{project_id}_chapters.md"
+        },
+    )
+
+
+# Import single chapter endpoint
+@router.post(
+    "/import", response_model=ChapterResponse, status_code=status.HTTP_201_CREATED
+)
+async def import_chapter(
+    project_id: int,
+    request: Request,
+    service: ChapterService = Depends(get_chapter_service),
+) -> ChapterResponse:
+    """Import a chapter from Markdown."""
+    try:
+        markdown_content = await request.body()
+        markdown_content = markdown_content.decode("utf-8")
+        chapter = service.import_chapter_markdown(project_id, markdown_content)
+        return ChapterResponse.model_validate(chapter)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+# Import bulk chapters endpoint
+@router.post(
+    "/import/bulk",
+    response_model=List[ChapterResponse],
+    status_code=status.HTTP_201_CREATED,
+)
+async def import_bulk_chapters(
+    project_id: int,
+    request: Request,
+    service: ChapterService = Depends(get_chapter_service),
+) -> List[ChapterResponse]:
+    """Import multiple chapters from a single Markdown document."""
+    try:
+        markdown_content = await request.body()
+        markdown_content = markdown_content.decode("utf-8")
+        chapters = service.import_bulk_markdown(project_id, markdown_content)
+        return [ChapterResponse.model_validate(ch) for ch in chapters]
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+# Reorder chapters endpoint
+@router.post("/reorder", response_model=List[ChapterResponse])
+def reorder_chapters(
+    project_id: int,
+    reorder_data: BulkChapterReorder,
+    service: ChapterService = Depends(get_chapter_service),
+) -> List[ChapterResponse]:
+    """Bulk reorder chapters."""
+    try:
+        chapters = service.bulk_reorder_chapters(project_id, reorder_data)
+        return [ChapterResponse.model_validate(ch) for ch in chapters]
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+# Get specific chapter endpoint
+@router.get("/{chapter_id}", response_model=ChapterResponse)
+def get_chapter(
+    project_id: int,
+    chapter_id: int,
+    service: ChapterService = Depends(get_chapter_service),
+) -> ChapterResponse:
+    """Get a specific chapter."""
+    chapter = service.get_chapter(project_id, chapter_id)
+    if not chapter:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Chapter not found"
+        )
+    return ChapterResponse.model_validate(chapter)
+
+
+# Update chapter endpoint
+@router.patch("/{chapter_id}", response_model=ChapterResponse)
+def update_chapter(
+    project_id: int,
+    chapter_id: int,
+    chapter_data: ChapterUpdate,
+    service: ChapterService = Depends(get_chapter_service),
+) -> ChapterResponse:
+    """Update a chapter."""
+    chapter = service.update_chapter(project_id, chapter_id, chapter_data)
+    if not chapter:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Chapter not found"
+        )
+    return ChapterResponse.model_validate(chapter)
+
+
+# Delete chapter endpoint
+@router.delete("/{chapter_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_chapter(
+    project_id: int,
+    chapter_id: int,
+    service: ChapterService = Depends(get_chapter_service),
+) -> None:
+    """Delete a chapter."""
+    success = service.delete_chapter(project_id, chapter_id)
+    if not success:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Chapter not found"
+        )
+
+
+# Export single chapter endpoint
+@router.get("/{chapter_id}/export")
+def export_chapter(
+    project_id: int,
+    chapter_id: int,
+    include_metadata: bool = False,
+    service: ChapterService = Depends(get_chapter_service),
+) -> Response:
+    """Export a chapter as Markdown."""
+    try:
+        markdown = service.export_chapter_markdown(
+            project_id, chapter_id, include_metadata
+        )
+        return Response(
+            content=markdown,
+            media_type="text/markdown; charset=utf-8",
+            headers={
+                "Content-Disposition": f"attachment; filename=chapter_{chapter_id}.md"
+            },
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -17,16 +17,12 @@ from app.validators.project import (
 router = APIRouter(prefix="/api/projects", tags=["projects"])
 
 
-def get_project_service(
-    db: Session = Depends(get_db_session)
-) -> ProjectService:
+def get_project_service(db: Session = Depends(get_db_session)) -> ProjectService:
     """Get project service instance."""
     return ProjectService(db)
 
 
-@router.post(
-    "", response_model=ProjectResponse, status_code=status.HTTP_201_CREATED
-)
+@router.post("", response_model=ProjectResponse, status_code=status.HTTP_201_CREATED)
 def create_project(
     project_data: ProjectCreate,
     service: ProjectService = Depends(get_project_service),

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -69,9 +69,7 @@ def init_session_factory(engine: Engine) -> None:
 def get_db_session() -> Generator[Session, None, None]:
     """Get database session for FastAPI dependency injection."""
     if SessionLocal is None:
-        raise RuntimeError(
-            "Database not initialized. Call init_session_factory first."
-        )
+        raise RuntimeError("Database not initialized. Call init_session_factory first.")
 
     db = SessionLocal()
     try:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
 from app.core.database import init_database, init_session_factory
 from app.core.storage import init_storage
-from app.api import projects_router
+from app.api import projects_router, chapters_router
 
 
 # Global database engine
@@ -85,6 +85,7 @@ async def health_check():
 
 # Include API routers
 app.include_router(projects_router)
+app.include_router(chapters_router)
 
 
 if __name__ == "__main__":

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -35,6 +35,5 @@ class Project(Base):
 
     def __repr__(self):
         return (
-            f"<Project(id={self.id}, title='{self.title}', "
-            f"author='{self.author}')>"
+            f"<Project(id={self.id}, title='{self.title}', " f"author='{self.author}')>"
         )

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,5 +1,6 @@
 """Business logic services."""
 
 from .project import ProjectService
+from .chapter import ChapterService
 
-__all__ = ["ProjectService"]
+__all__ = ["ProjectService", "ChapterService"]

--- a/backend/app/services/chapter.py
+++ b/backend/app/services/chapter.py
@@ -1,0 +1,291 @@
+"""Service layer for Chapter operations."""
+
+from typing import List, Optional
+from sqlalchemy.orm import Session
+from sqlalchemy import and_
+
+from app.models import Chapter, Project
+from app.validators.chapter import (
+    ChapterCreate,
+    ChapterUpdate,
+    BulkChapterReorder,
+)
+
+
+class ChapterService:
+    """Service for managing chapters."""
+
+    def __init__(self, db: Session):
+        """Initialize ChapterService with database session."""
+        self.db = db
+
+    def create_chapter(self, project_id: int, chapter_data: ChapterCreate) -> Chapter:
+        """Create a new chapter for a project."""
+        # Verify project exists
+        project = self.db.query(Project).filter(Project.id == project_id).first()
+        if not project:
+            raise ValueError(f"Project with id {project_id} not found")
+
+        # Auto-assign position if not provided
+        position = chapter_data.position
+        if position is None:
+            # Get the max position for this project
+            max_position = (
+                self.db.query(Chapter).filter(Chapter.project_id == project_id).count()
+            )
+            position = max_position + 1
+
+        # Create chapter
+        chapter = Chapter(
+            project_id=project_id,
+            title=chapter_data.title,
+            content=chapter_data.content,
+            position=position,
+        )
+
+        self.db.add(chapter)
+        self.db.commit()
+        self.db.refresh(chapter)
+
+        return chapter
+
+    def get_chapter(self, project_id: int, chapter_id: int) -> Optional[Chapter]:
+        """Get a chapter by ID."""
+        return (
+            self.db.query(Chapter)
+            .filter(and_(Chapter.id == chapter_id, Chapter.project_id == project_id))
+            .first()
+        )
+
+    def list_chapters(self, project_id: int) -> List[Chapter]:
+        """List all chapters for a project, ordered by position."""
+        return (
+            self.db.query(Chapter)
+            .filter(Chapter.project_id == project_id)
+            .order_by(Chapter.position)
+            .all()
+        )
+
+    def update_chapter(
+        self, project_id: int, chapter_id: int, chapter_data: ChapterUpdate
+    ) -> Optional[Chapter]:
+        """Update a chapter."""
+        chapter = self.get_chapter(project_id, chapter_id)
+        if not chapter:
+            return None
+
+        # Handle position change (reordering)
+        if (
+            chapter_data.position is not None
+            and chapter_data.position != chapter.position
+        ):
+            self._reorder_chapters(project_id, chapter_id, chapter_data.position)
+
+        # Update other fields
+        update_data = chapter_data.model_dump(exclude_unset=True, exclude={"position"})
+        for field, value in update_data.items():
+            setattr(chapter, field, value)
+
+        self.db.commit()
+        self.db.refresh(chapter)
+
+        return chapter
+
+    def delete_chapter(self, project_id: int, chapter_id: int) -> bool:
+        """Delete a chapter and reorder remaining chapters."""
+        chapter = self.get_chapter(project_id, chapter_id)
+        if not chapter:
+            return False
+
+        deleted_position = chapter.position
+
+        # Delete the chapter
+        self.db.delete(chapter)
+        self.db.commit()
+
+        # Reorder remaining chapters
+        remaining_chapters = (
+            self.db.query(Chapter)
+            .filter(
+                and_(
+                    Chapter.project_id == project_id,
+                    Chapter.position > deleted_position,
+                )
+            )
+            .all()
+        )
+
+        for ch in remaining_chapters:
+            ch.position -= 1
+
+        self.db.commit()
+
+        return True
+
+    def _reorder_chapters(
+        self, project_id: int, chapter_id: int, new_position: int
+    ) -> None:
+        """Reorder chapters when one is moved."""
+        chapter = self.get_chapter(project_id, chapter_id)
+        if not chapter:
+            return
+
+        old_position = chapter.position
+
+        if old_position == new_position:
+            return
+
+        # Get all chapters that need to be reordered
+        if new_position < old_position:
+            # Moving up - shift others down
+            affected_chapters = (
+                self.db.query(Chapter)
+                .filter(
+                    and_(
+                        Chapter.project_id == project_id,
+                        Chapter.position >= new_position,
+                        Chapter.position < old_position,
+                        Chapter.id != chapter_id,
+                    )
+                )
+                .all()
+            )
+            for ch in affected_chapters:
+                ch.position += 1
+        else:
+            # Moving down - shift others up
+            affected_chapters = (
+                self.db.query(Chapter)
+                .filter(
+                    and_(
+                        Chapter.project_id == project_id,
+                        Chapter.position > old_position,
+                        Chapter.position <= new_position,
+                        Chapter.id != chapter_id,
+                    )
+                )
+                .all()
+            )
+            for ch in affected_chapters:
+                ch.position -= 1
+
+        # Update the moved chapter's position
+        chapter.position = new_position
+        self.db.commit()
+
+    def bulk_reorder_chapters(
+        self, project_id: int, reorder_data: BulkChapterReorder
+    ) -> List[Chapter]:
+        """Bulk reorder multiple chapters."""
+        # Verify all chapters belong to the project
+        chapter_ids = [ch.chapter_id for ch in reorder_data.chapters]
+        chapters = (
+            self.db.query(Chapter)
+            .filter(and_(Chapter.project_id == project_id, Chapter.id.in_(chapter_ids)))
+            .all()
+        )
+
+        if len(chapters) != len(chapter_ids):
+            raise ValueError("Some chapters not found or don't belong to project")
+
+        # Apply new positions
+        for reorder_item in reorder_data.chapters:
+            chapter = next(
+                (ch for ch in chapters if ch.id == reorder_item.chapter_id), None
+            )
+            if chapter:
+                chapter.position = reorder_item.new_position
+
+        self.db.commit()
+
+        # Return updated chapters in order
+        return self.list_chapters(project_id)
+
+    def export_chapter_markdown(
+        self, project_id: int, chapter_id: int, include_metadata: bool = False
+    ) -> str:
+        """Export a chapter as Markdown."""
+        chapter = self.get_chapter(project_id, chapter_id)
+        if not chapter:
+            raise ValueError(f"Chapter {chapter_id} not found")
+
+        markdown = f"# {chapter.title}\n\n"
+
+        if include_metadata:
+            markdown += f"<!-- Position: {chapter.position} -->\n"
+            markdown += f"<!-- Created: {chapter.created_at.isoformat()} -->\n"
+            markdown += f"<!-- Updated: {chapter.updated_at.isoformat()} -->\n\n"
+
+        markdown += chapter.content
+
+        return markdown
+
+    def export_all_chapters_markdown(
+        self, project_id: int, include_metadata: bool = False
+    ) -> str:
+        """Export all chapters as a single Markdown document."""
+        chapters = self.list_chapters(project_id)
+
+        if not chapters:
+            return ""
+
+        markdown_parts = []
+        for chapter in chapters:
+            markdown_parts.append(
+                self.export_chapter_markdown(project_id, chapter.id, include_metadata)
+            )
+
+        return "\n\n---\n\n".join(markdown_parts)
+
+    def import_chapter_markdown(
+        self, project_id: int, markdown_content: str
+    ) -> Chapter:
+        """Import a chapter from Markdown content."""
+        # Verify project exists
+        project = self.db.query(Project).filter(Project.id == project_id).first()
+        if not project:
+            raise ValueError(f"Project with id {project_id} not found")
+
+        # Extract title from first H1
+        lines = markdown_content.strip().split("\n")
+        title = None
+        content_lines = []
+
+        for i, line in enumerate(lines):
+            if line.startswith("# ") and title is None:
+                title = line[2:].strip()
+            else:
+                content_lines.append(line)
+
+        if not title:
+            raise ValueError("Markdown must contain a title (H1 heading)")
+
+        content = "\n".join(content_lines).strip()
+
+        # Create chapter with extracted data
+        chapter_data = ChapterCreate(
+            title=title,
+            content=content,
+        )
+
+        return self.create_chapter(project_id, chapter_data)
+
+    def import_bulk_markdown(
+        self, project_id: int, markdown_content: str
+    ) -> List[Chapter]:
+        """Import multiple chapters from a single Markdown document."""
+        # Split by horizontal rules
+        chapter_sections = markdown_content.split("\n---\n")
+
+        created_chapters = []
+        for section in chapter_sections:
+            section = section.strip()
+            if section:
+                try:
+                    chapter = self.import_chapter_markdown(project_id, section)
+                    created_chapters.append(chapter)
+                except ValueError:
+                    # Skip sections without proper title
+                    continue
+
+        return created_chapters

--- a/backend/app/validators/__init__.py
+++ b/backend/app/validators/__init__.py
@@ -6,10 +6,28 @@ from .project import (
     ProjectResponse,
     ProjectListResponse,
 )
+from .chapter import (
+    ChapterBase,
+    ChapterCreate,
+    ChapterUpdate,
+    ChapterResponse,
+    ChapterImport,
+    ChapterExport,
+    ChapterReorder,
+    BulkChapterReorder,
+)
 
 __all__ = [
     "ProjectCreate",
     "ProjectUpdate",
     "ProjectResponse",
     "ProjectListResponse",
+    "ChapterBase",
+    "ChapterCreate",
+    "ChapterUpdate",
+    "ChapterResponse",
+    "ChapterImport",
+    "ChapterExport",
+    "ChapterReorder",
+    "BulkChapterReorder",
 ]

--- a/backend/app/validators/chapter.py
+++ b/backend/app/validators/chapter.py
@@ -1,0 +1,91 @@
+"""Pydantic schemas for Chapter validation."""
+
+from typing import Optional
+from datetime import datetime
+from pydantic import BaseModel, Field, field_validator
+
+
+class ChapterBase(BaseModel):
+    """Base schema for Chapter."""
+
+    title: str = Field(..., min_length=1, max_length=255)
+    content: str = Field(default="")
+    position: Optional[int] = Field(None, ge=1)
+
+
+class ChapterCreate(ChapterBase):
+    """Schema for creating a Chapter."""
+
+    pass
+
+
+class ChapterUpdate(BaseModel):
+    """Schema for updating a Chapter."""
+
+    title: Optional[str] = Field(None, min_length=1, max_length=255)
+    content: Optional[str] = None
+    position: Optional[int] = Field(None, ge=1)
+
+
+class ChapterResponse(BaseModel):
+    """Schema for Chapter response."""
+
+    id: int
+    project_id: int
+    title: str
+    content: str
+    position: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ChapterImport(BaseModel):
+    """Schema for importing a chapter from Markdown."""
+
+    markdown_content: str = Field(..., min_length=1)
+
+    @field_validator("markdown_content")
+    @classmethod
+    def extract_title_from_markdown(cls, v: str) -> str:
+        """Validate that markdown has a title."""
+        lines = v.strip().split("\n")
+        if not lines:
+            raise ValueError("Markdown content cannot be empty")
+
+        # Look for first heading
+        for line in lines:
+            if line.startswith("# "):
+                return v
+
+        raise ValueError("Markdown must contain at least one H1 heading for title")
+
+
+class ChapterExport(BaseModel):
+    """Schema for exporting a chapter to Markdown."""
+
+    include_metadata: bool = Field(default=False)
+    include_position: bool = Field(default=True)
+
+
+class ChapterReorder(BaseModel):
+    """Schema for reordering chapters."""
+
+    chapter_id: int
+    new_position: int = Field(..., ge=1)
+
+
+class BulkChapterReorder(BaseModel):
+    """Schema for bulk reordering chapters."""
+
+    chapters: list[ChapterReorder]
+
+    @field_validator("chapters")
+    @classmethod
+    def validate_unique_positions(cls, v: list[ChapterReorder]) -> list:
+        """Ensure all positions are unique."""
+        positions = [ch.new_position for ch in v]
+        if len(positions) != len(set(positions)):
+            raise ValueError("All positions must be unique")
+        return v

--- a/backend/tests/test_api_chapters.py
+++ b/backend/tests/test_api_chapters.py
@@ -1,0 +1,429 @@
+"""Tests for Chapter CRUD API endpoints."""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core.database import Base, get_db_session
+from app.main import app
+
+# Import models to register with Base (noqa: F401)
+from app.models import Project, Chapter  # noqa: F401
+
+
+# Test database setup
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def override_get_db():
+    """Override database dependency for testing."""
+    try:
+        db = TestingSessionLocal()
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture
+def client():
+    """Create test client with test database."""
+    Base.metadata.create_all(bind=engine)
+    app.dependency_overrides[get_db_session] = override_get_db
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+    Base.metadata.drop_all(bind=engine)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def test_project(client):
+    """Create a test project for chapter tests."""
+    project_data = {
+        "title": "Test Book for Chapters",
+        "author": "Chapter Tester",
+        "description": "A book to test chapter functionality",
+    }
+    response = client.post("/api/projects", json=project_data)
+    return response.json()
+
+
+class TestChapterCreate:
+    """Test chapter creation endpoint."""
+
+    def test_create_chapter_success(self, client, test_project):
+        """Test successful chapter creation."""
+        chapter_data = {
+            "title": "Chapter 1: Introduction",
+            "content": "This is the introduction content.",
+            "position": 1,
+        }
+
+        response = client.post(
+            f"/api/projects/{test_project['id']}/chapters", json=chapter_data
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["title"] == chapter_data["title"]
+        assert data["content"] == chapter_data["content"]
+        assert data["position"] == chapter_data["position"]
+        assert data["project_id"] == test_project["id"]
+        assert "id" in data
+        assert "created_at" in data
+        assert "updated_at" in data
+
+    def test_create_chapter_minimal(self, client, test_project):
+        """Test chapter creation with minimal data."""
+        chapter_data = {
+            "title": "Minimal Chapter",
+        }
+
+        response = client.post(
+            f"/api/projects/{test_project['id']}/chapters", json=chapter_data
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["title"] == chapter_data["title"]
+        assert data["content"] == ""
+        assert data["position"] == 1  # Auto-assigned
+
+    def test_create_chapter_auto_position(self, client, test_project):
+        """Test automatic position assignment for chapters."""
+        # Create first chapter
+        chapter1 = {
+            "title": "Chapter 1",
+            "content": "First chapter",
+        }
+        response1 = client.post(
+            f"/api/projects/{test_project['id']}/chapters", json=chapter1
+        )
+        assert response1.json()["position"] == 1
+
+        # Create second chapter without position
+        chapter2 = {
+            "title": "Chapter 2",
+            "content": "Second chapter",
+        }
+        response2 = client.post(
+            f"/api/projects/{test_project['id']}/chapters", json=chapter2
+        )
+        assert response2.json()["position"] == 2
+
+    def test_create_chapter_nonexistent_project(self, client):
+        """Test chapter creation for nonexistent project."""
+        chapter_data = {
+            "title": "Orphan Chapter",
+            "content": "This should fail",
+        }
+
+        response = client.post("/api/projects/999999/chapters", json=chapter_data)
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    def test_create_chapter_validation_error(self, client, test_project):
+        """Test chapter creation with invalid data."""
+        # Empty title
+        chapter_data = {
+            "title": "",
+            "content": "Content without title",
+        }
+
+        response = client.post(
+            f"/api/projects/{test_project['id']}/chapters", json=chapter_data
+        )
+
+        assert response.status_code == 422
+
+
+class TestChapterRead:
+    """Test chapter reading endpoints."""
+
+    def test_get_chapter_by_id(self, client, test_project):
+        """Test getting a chapter by ID."""
+        # Create a chapter first
+        chapter_data = {
+            "title": "Chapter to Retrieve",
+            "content": "Some content",
+        }
+        create_response = client.post(
+            f"/api/projects/{test_project['id']}/chapters", json=chapter_data
+        )
+        chapter_id = create_response.json()["id"]
+
+        # Get the chapter
+        response = client.get(
+            f"/api/projects/{test_project['id']}/chapters/{chapter_id}"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == chapter_id
+        assert data["title"] == chapter_data["title"]
+        assert data["content"] == chapter_data["content"]
+        assert data["project_id"] == test_project["id"]
+
+    def test_get_nonexistent_chapter(self, client, test_project):
+        """Test getting a chapter that doesn't exist."""
+        response = client.get(f"/api/projects/{test_project['id']}/chapters/999999")
+
+        assert response.status_code == 404
+        assert "chapter not found" in response.json()["detail"].lower()
+
+    def test_list_chapters(self, client, test_project):
+        """Test listing all chapters for a project."""
+        # Create multiple chapters
+        chapters = [
+            {"title": "Chapter 1", "content": "Content 1", "position": 1},
+            {"title": "Chapter 2", "content": "Content 2", "position": 2},
+            {"title": "Chapter 3", "content": "Content 3", "position": 3},
+        ]
+
+        for chapter in chapters:
+            client.post(f"/api/projects/{test_project['id']}/chapters", json=chapter)
+
+        # List all chapters
+        response = client.get(f"/api/projects/{test_project['id']}/chapters")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 3
+        # Should be ordered by position
+        assert data[0]["title"] == "Chapter 1"
+        assert data[1]["title"] == "Chapter 2"
+        assert data[2]["title"] == "Chapter 3"
+
+    def test_list_chapters_empty(self, client, test_project):
+        """Test listing chapters when none exist."""
+        response = client.get(f"/api/projects/{test_project['id']}/chapters")
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+class TestChapterUpdate:
+    """Test chapter update endpoint."""
+
+    def test_update_chapter_content(self, client, test_project):
+        """Test updating chapter content."""
+        # Create a chapter
+        chapter_data = {
+            "title": "Original Title",
+            "content": "Original content",
+            "position": 1,
+        }
+        create_response = client.post(
+            f"/api/projects/{test_project['id']}/chapters", json=chapter_data
+        )
+        chapter_id = create_response.json()["id"]
+
+        # Update the chapter
+        update_data = {
+            "title": "Updated Title",
+            "content": "Updated content with more details",
+        }
+        response = client.patch(
+            f"/api/projects/{test_project['id']}/chapters/{chapter_id}",
+            json=update_data,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == chapter_id
+        assert data["title"] == update_data["title"]
+        assert data["content"] == update_data["content"]
+        assert data["position"] == 1  # Unchanged
+
+    def test_update_chapter_position(self, client, test_project):
+        """Test updating chapter position (reordering)."""
+        # Create multiple chapters
+        chapters = [
+            {"title": "Chapter 1", "position": 1},
+            {"title": "Chapter 2", "position": 2},
+            {"title": "Chapter 3", "position": 3},
+        ]
+        chapter_ids = []
+        for chapter in chapters:
+            response = client.post(
+                f"/api/projects/{test_project['id']}/chapters", json=chapter
+            )
+            chapter_ids.append(response.json()["id"])
+
+        # Move Chapter 3 to position 1
+        update_data = {"position": 1}
+        response = client.patch(
+            f"/api/projects/{test_project['id']}/chapters/{chapter_ids[2]}",
+            json=update_data,
+        )
+
+        assert response.status_code == 200
+
+        # Verify new order
+        list_response = client.get(f"/api/projects/{test_project['id']}/chapters")
+        chapters_list = list_response.json()
+
+        assert chapters_list[0]["title"] == "Chapter 3"
+        assert chapters_list[0]["position"] == 1
+        assert chapters_list[1]["position"] == 2
+        assert chapters_list[2]["position"] == 3
+
+    def test_update_nonexistent_chapter(self, client, test_project):
+        """Test updating a chapter that doesn't exist."""
+        update_data = {"title": "New Title"}
+        response = client.patch(
+            f"/api/projects/{test_project['id']}/chapters/999999", json=update_data
+        )
+
+        assert response.status_code == 404
+
+
+class TestChapterDelete:
+    """Test chapter deletion endpoint."""
+
+    def test_delete_chapter(self, client, test_project):
+        """Test deleting a chapter."""
+        # Create a chapter
+        chapter_data = {
+            "title": "Chapter to Delete",
+            "content": "This will be deleted",
+        }
+        create_response = client.post(
+            f"/api/projects/{test_project['id']}/chapters", json=chapter_data
+        )
+        chapter_id = create_response.json()["id"]
+
+        # Delete the chapter
+        response = client.delete(
+            f"/api/projects/{test_project['id']}/chapters/{chapter_id}"
+        )
+
+        assert response.status_code == 204
+
+        # Verify it's deleted
+        get_response = client.get(
+            f"/api/projects/{test_project['id']}/chapters/{chapter_id}"
+        )
+        assert get_response.status_code == 404
+
+    def test_delete_chapter_reorders_positions(self, client, test_project):
+        """Test that deleting a chapter reorders remaining chapters."""
+        # Create multiple chapters
+        chapters = [
+            {"title": "Chapter 1", "position": 1},
+            {"title": "Chapter 2", "position": 2},
+            {"title": "Chapter 3", "position": 3},
+        ]
+        chapter_ids = []
+        for chapter in chapters:
+            response = client.post(
+                f"/api/projects/{test_project['id']}/chapters", json=chapter
+            )
+            chapter_ids.append(response.json()["id"])
+
+        # Delete Chapter 2
+        client.delete(f"/api/projects/{test_project['id']}/chapters/{chapter_ids[1]}")
+
+        # Verify remaining chapters are reordered
+        list_response = client.get(f"/api/projects/{test_project['id']}/chapters")
+        remaining = list_response.json()
+
+        assert len(remaining) == 2
+        assert remaining[0]["title"] == "Chapter 1"
+        assert remaining[0]["position"] == 1
+        assert remaining[1]["title"] == "Chapter 3"
+        assert remaining[1]["position"] == 2
+
+    def test_delete_nonexistent_chapter(self, client, test_project):
+        """Test deleting a chapter that doesn't exist."""
+        response = client.delete(f"/api/projects/{test_project['id']}/chapters/999999")
+
+        assert response.status_code == 404
+
+
+class TestChapterImportExport:
+    """Test chapter import/export functionality."""
+
+    def test_export_chapter_markdown(self, client, test_project):
+        """Test exporting a chapter as Markdown."""
+        # Create a chapter with Markdown content
+        chapter_data = {
+            "title": "Chapter with Markdown",
+            "content": "# Heading\n\nSome **bold** text and *italic* text.",
+        }
+        create_response = client.post(
+            f"/api/projects/{test_project['id']}/chapters", json=chapter_data
+        )
+        chapter_id = create_response.json()["id"]
+
+        # Export as Markdown
+        response = client.get(
+            f"/api/projects/{test_project['id']}/chapters/{chapter_id}/export"
+        )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "text/markdown; charset=utf-8"
+        content = response.text
+        assert "# Chapter with Markdown" in content
+        assert "# Heading" in content
+        assert "**bold**" in content
+
+    def test_import_chapter_markdown(self, client, test_project):
+        """Test importing a chapter from Markdown."""
+        markdown_content = """# Imported Chapter
+
+## Introduction
+
+This chapter was imported from Markdown.
+
+- Point 1
+- Point 2
+- Point 3
+
+**Important:** This is a test.
+"""
+
+        response = client.post(
+            f"/api/projects/{test_project['id']}/chapters/import",
+            content=markdown_content,
+            headers={"content-type": "text/markdown"},
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["title"] == "Imported Chapter"
+        assert "## Introduction" in data["content"]
+        assert "This chapter was imported" in data["content"]
+
+    def test_bulk_export_chapters(self, client, test_project):
+        """Test exporting all chapters as a single Markdown file."""
+        # Create multiple chapters
+        chapters = [
+            {"title": "Chapter 1", "content": "Content of chapter 1"},
+            {"title": "Chapter 2", "content": "Content of chapter 2"},
+            {"title": "Chapter 3", "content": "Content of chapter 3"},
+        ]
+        for chapter in chapters:
+            client.post(f"/api/projects/{test_project['id']}/chapters", json=chapter)
+
+        # Export all chapters
+        response = client.get(f"/api/projects/{test_project['id']}/chapters/export")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "text/markdown; charset=utf-8"
+        content = response.text
+        assert "# Chapter 1" in content
+        assert "# Chapter 2" in content
+        assert "# Chapter 3" in content
+        assert "Content of chapter 1" in content

--- a/backend/tests/test_api_projects.py
+++ b/backend/tests/test_api_projects.py
@@ -8,6 +8,7 @@ from sqlalchemy.pool import StaticPool
 
 from app.core.database import Base, get_db_session
 from app.main import app
+
 # Import models to register with Base (noqa: F401)
 from app.models import Project, Chapter  # noqa: F401
 
@@ -20,9 +21,7 @@ engine = create_engine(
     connect_args={"check_same_thread": False},
     poolclass=StaticPool,
 )
-TestingSessionLocal = sessionmaker(
-    autocommit=False, autoflush=False, bind=engine
-)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
 def override_get_db():
@@ -185,9 +184,7 @@ class TestProjectUpdate:
             "title": "Updated Title",
             "description": "Updated description",
         }
-        response = client.patch(
-            f"/api/projects/{project_id}", json=update_data
-        )
+        response = client.patch(f"/api/projects/{project_id}", json=update_data)
 
         assert response.status_code == 200
         data = response.json()
@@ -221,9 +218,7 @@ class TestProjectUpdate:
                 "line_height": 1.5,
             }
         }
-        response = client.patch(
-            f"/api/projects/{project_id}", json=update_data
-        )
+        response = client.patch(f"/api/projects/{project_id}", json=update_data)
 
         assert response.status_code == 200
         data = response.json()

--- a/backend/tests/test_infrastructure.py
+++ b/backend/tests/test_infrastructure.py
@@ -37,9 +37,7 @@ class TestDatabaseSetup:
         inspector = inspect(engine)
 
         # Check projects table structure
-        project_columns = {
-            col["name"] for col in inspector.get_columns("projects")
-        }
+        project_columns = {col["name"] for col in inspector.get_columns("projects")}
         expected_project_cols = {
             "id",
             "title",
@@ -52,9 +50,7 @@ class TestDatabaseSetup:
         assert expected_project_cols.issubset(project_columns)
 
         # Check chapters table structure
-        chapter_columns = {
-            col["name"] for col in inspector.get_columns("chapters")
-        }
+        chapter_columns = {col["name"] for col in inspector.get_columns("chapters")}
         expected_chapter_cols = {
             "id",
             "project_id",


### PR DESCRIPTION
## 📚 PR #3 - Gestionnaire de Chapitres

### ✨ Fonctionnalités implémentées

- **CRUD API complet** pour les chapitres (`/api/projects/{id}/chapters`)
- **Gestion automatique des positions** avec réorganisation intelligente
- **Import/Export Markdown** avec extraction automatique du titre H1
- **Réorganisation bulk** des chapitres avec validation
- **18 tests unitaires** couvrant tous les cas d'usage

### 🏗️ Architecture

#### Schémas Pydantic (`validators/chapter.py`)
- `ChapterCreate` : Création avec position auto-assignée
- `ChapterUpdate` : Mise à jour partielle
- `ChapterResponse` : Réponse complète avec timestamps
- `ChapterImport/Export` : Import/Export Markdown
- `BulkChapterReorder` : Réorganisation multiple avec validation

#### Service Layer (`services/chapter.py`)
- Gestion automatique des positions (auto-increment)
- Réorganisation intelligente lors des déplacements
- Import Markdown avec extraction H1
- Export avec métadonnées optionnelles

#### API Endpoints (`api/chapters.py`)
- `POST /chapters` : Créer un chapitre
- `GET /chapters` : Lister les chapitres (triés par position)
- `GET /chapters/{id}` : Obtenir un chapitre
- `PATCH /chapters/{id}` : Mettre à jour
- `DELETE /chapters/{id}` : Supprimer avec réorganisation
- `POST /chapters/import` : Importer depuis Markdown
- `GET /chapters/export` : Exporter tous en Markdown
- `POST /chapters/reorder` : Réorganisation bulk

### ✅ Tests

**18 tests unitaires** ajoutés :
- CRUD complet avec validation
- Position automatique et réorganisation
- Import/Export Markdown
- Gestion des erreurs et cas limites

**Total projet : 44 tests** ✅
- 18 chapitres
- 13 projets  
- 13 infrastructure

### 🔧 Qualité du code

- ✅ Code formaté avec **black**
- ✅ Validé avec **flake8** (sauf E501 line length)
- ✅ Type hints complets
- ✅ Docstrings descriptives
- ✅ Approche TDD respectée

### 📝 Notes techniques

- Routes ordonnées correctement (`/export` avant `/{id}`)
- Import utilise `Request.body()` pour le contenu Markdown
- Validation des positions uniques dans `BulkChapterReorder`
- Cascade delete configurée pour supprimer les chapitres avec le projet